### PR TITLE
feat(applications & landing): add manager/tenant application dashboards, ApplicationCard, HeroSection, and landing integration  

### DIFF
--- a/frontend/src/app/(dashboard)/managers/applications/page.tsx
+++ b/frontend/src/app/(dashboard)/managers/applications/page.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+import ApplicationCard from "@/components/ApplicationCard";
+import Header from "@/components/Header";
+import Loading from "@/components/Loading";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+  useGetApplicationsQuery,
+  useGetAuthUserQuery,
+  useUpdateApplicationStatusMutation,
+} from "@/state/api";
+import { CircleCheckBig, Download, File, Hospital } from "lucide-react";
+import Link from "next/link";
+import React, { useState } from "react";
+
+const Applications = () => {
+  const { data: authUser } = useGetAuthUserQuery();
+  const [activeTab, setActiveTab] = useState("all");
+
+  const {
+    data: applications,
+    isLoading,
+    isError,
+  } = useGetApplicationsQuery(
+    {
+      userId: authUser?.cognitoInfo?.userId,
+      userType: "manager",
+    },
+    {
+      skip: !authUser?.cognitoInfo?.userId,
+    }
+  );
+  const [updateApplicationStatus] = useUpdateApplicationStatusMutation();
+
+  const handleStatusChange = async (id: number, status: string) => {
+    await updateApplicationStatus({ id, status });
+  };
+
+  if (isLoading) return <Loading />;
+  if (isError || !applications) return <div>Error fetching applications</div>;
+
+  const filteredApplications = applications?.filter((application) => {
+    if (activeTab === "all") return true;
+    return application.status.toLowerCase() === activeTab;
+  });
+
+  return (
+    <div className="dashboard-container">
+      <Header
+        title="Applications"
+        subtitle="View and manage applications for your properties"
+      />
+      <Tabs
+        value={activeTab}
+        onValueChange={setActiveTab}
+        className="w-full my-5"
+      >
+        <TabsList className="grid w-full grid-cols-4">
+          <TabsTrigger value="all">All</TabsTrigger>
+          <TabsTrigger value="pending">Pending</TabsTrigger>
+          <TabsTrigger value="approved">Approved</TabsTrigger>
+          <TabsTrigger value="denied">Denied</TabsTrigger>
+        </TabsList>
+        {["all", "pending", "approved", "denied"].map((tab) => (
+          <TabsContent key={tab} value={tab} className="mt-5 w-full">
+            {filteredApplications
+              .filter(
+                (application) =>
+                  tab === "all" || application.status.toLowerCase() === tab
+              )
+              .map((application) => (
+                <ApplicationCard
+                  key={application.id}
+                  application={application}
+                  userType="manager"
+                >
+                  <div className="flex justify-between gap-5 w-full pb-4 px-4">
+                    {/* Colored Section Status */}
+                    <div
+                      className={`p-4 text-green-700 grow ${
+                        application.status === "Approved"
+                          ? "bg-green-100"
+                          : application.status === "Denied"
+                          ? "bg-red-100"
+                          : "bg-yellow-100"
+                      }`}
+                    >
+                      <div className="flex flex-wrap items-center">
+                        <File className="w-5 h-5 mr-2 flex-shrink-0" />
+                        <span className="mr-2">
+                          Application submitted on{" "}
+                          {new Date(
+                            application.applicationDate
+                          ).toLocaleDateString()}
+                          .
+                        </span>
+                        <CircleCheckBig className="w-5 h-5 mr-2 flex-shrink-0" />
+                        <span
+                          className={`font-semibold ${
+                            application.status === "Approved"
+                              ? "text-green-800"
+                              : application.status === "Denied"
+                              ? "text-red-800"
+                              : "text-yellow-800"
+                          }`}
+                        >
+                          {application.status === "Approved" &&
+                            "This application has been approved."}
+                          {application.status === "Denied" &&
+                            "This application has been denied."}
+                          {application.status === "Pending" &&
+                            "This application is pending review."}
+                        </span>
+                      </div>
+                    </div>
+
+                    {/* Right Buttons */}
+                    <div className="flex gap-2">
+                      <Link
+                        href={`/managers/properties/${application.property.id}`}
+                        className={`bg-white border border-gray-300 text-gray-700 py-2 px-4 
+                          rounded-md flex items-center justify-center hover:bg-primary-700 hover:text-primary-50`}
+                        scroll={false}
+                      >
+                        <Hospital className="w-5 h-5 mr-2" />
+                        Property Details
+                      </Link>
+                      {application.status === "Approved" && (
+                        <button
+                          className={`bg-white border border-gray-300 text-gray-700 py-2 px-4
+                          rounded-md flex items-center justify-center hover:bg-primary-700 hover:text-primary-50`}
+                        >
+                          <Download className="w-5 h-5 mr-2" />
+                          Download Agreement
+                        </button>
+                      )}
+                      {application.status === "Pending" && (
+                        <>
+                          <button
+                            className="px-4 py-2 text-sm text-white bg-green-600 rounded hover:bg-green-500"
+                            onClick={() =>
+                              handleStatusChange(application.id, "Approved")
+                            }
+                          >
+                            Approve
+                          </button>
+                          <button
+                            className="px-4 py-2 text-sm text-white bg-red-600 rounded hover:bg-red-500"
+                            onClick={() =>
+                              handleStatusChange(application.id, "Denied")
+                            }
+                          >
+                            Deny
+                          </button>
+                        </>
+                      )}
+                      {application.status === "Denied" && (
+                        <button
+                          className={`bg-gray-800 text-white py-2 px-4 rounded-md flex items-center
+                          justify-center hover:bg-secondary-500 hover:text-primary-50`}
+                        >
+                          Contact User
+                        </button>
+                      )}
+                    </div>
+                  </div>
+                </ApplicationCard>
+              ))}
+          </TabsContent>
+        ))}
+      </Tabs>
+    </div>
+  );
+};
+
+export default Applications;

--- a/frontend/src/app/(dashboard)/tenants/applications/page.tsx
+++ b/frontend/src/app/(dashboard)/tenants/applications/page.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import ApplicationCard from "@/components/ApplicationCard";
+import Header from "@/components/Header";
+import Loading from "@/components/Loading";
+import { useGetApplicationsQuery, useGetAuthUserQuery } from "@/state/api";
+import { CircleCheckBig, Clock, Download, XCircle } from "lucide-react";
+import React from "react";
+
+const Applications = () => {
+  const { data: authUser } = useGetAuthUserQuery();
+  const {
+    data: applications,
+    isLoading,
+    isError,
+  } = useGetApplicationsQuery({
+    userId: authUser?.cognitoInfo?.userId,
+    userType: "tenant",
+  });
+
+  if (isLoading) return <Loading />;
+  if (isError || !applications) return <div>Error fetching applications</div>;
+
+  return (
+    <div className="dashboard-container">
+      <Header
+        title="Applications"
+        subtitle="Track and manage your property rental applications"
+      />
+      <div className="w-full">
+        {applications?.map((application) => (
+          <ApplicationCard
+            key={application.id}
+            application={application}
+            userType="renter"
+          >
+            <div className="flex justify-between gap-5 w-full pb-4 px-4">
+              {application.status === "Approved" ? (
+                <div className="bg-green-100 p-4 text-green-700 grow flex items-center">
+                  <CircleCheckBig className="w-5 h-5 mr-2" />
+                  The property is being rented by you until{" "}
+                  {new Date(application.lease?.endDate).toLocaleDateString()}
+                </div>
+              ) : application.status === "Pending" ? (
+                <div className="bg-yellow-100 p-4 text-yellow-700 grow flex items-center">
+                  <Clock className="w-5 h-5 mr-2" />
+                  Your application is pending approval
+                </div>
+              ) : (
+                <div className="bg-red-100 p-4 text-red-700 grow flex items-center">
+                  <XCircle className="w-5 h-5 mr-2" />
+                  Your application has been denied
+                </div>
+              )}
+
+              <button
+                className={`bg-white border border-gray-300 text-gray-700 py-2 px-4
+                          rounded-md flex items-center justify-center hover:bg-primary-700 hover:text-primary-50`}
+              >
+                <Download className="w-5 h-5 mr-2" />
+                Download Agreement
+              </button>
+            </div>
+          </ApplicationCard>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default Applications;

--- a/frontend/src/app/(nondashboard)/landing/HeroSection.tsx
+++ b/frontend/src/app/(nondashboard)/landing/HeroSection.tsx
@@ -1,11 +1,50 @@
 "use client";
 import Image from 'next/image'
-import React from 'react'
+import React, { useState } from 'react'
 import { motion } from 'framer-motion'
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
+import { useDispatch } from "react-redux";
+import { useRouter } from "next/navigation";
+import { setFilters } from "@/state";
 
 const HeroSection = () => {
+  const dispatch = useDispatch();
+  const [searchQuery, setSearchQuery] = useState("");
+  const router = useRouter();
+
+  const handleLocationSearch = async () => {
+    try {
+      const trimmedQuery = searchQuery.trim();
+      if (!trimmedQuery) return;
+
+      const response = await fetch(
+        `https://api.mapbox.com/geocoding/v5/mapbox.places/${encodeURIComponent(
+          trimmedQuery
+        )}.json?access_token=${
+          process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN
+        }&fuzzyMatch=true`
+      );
+      const data = await response.json();
+      if (data.features && data.features.length > 0) {
+        const [lng, lat] = data.features[0].center;
+        dispatch(
+          setFilters({
+            location: trimmedQuery,
+            coordinates: [lat, lng],
+          })
+        );
+        const params = new URLSearchParams({
+          location: trimmedQuery,
+          lat: lat.toString(),
+          lng: lng,
+        });
+        router.push(`/search?${params.toString()}`);
+      }
+    } catch (error) {
+      console.error("error search location:", error);
+    }
+  };
   return (
     <div className='relative h-screen'>
         <Image

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import Providers from "./providers";
+import { Toaster } from "@/components/ui/sonner";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -29,7 +30,7 @@ export default function RootLayout({
         <Providers>
         {children}
         </Providers>
-
+      <Toaster closeButton />
       </body>
     </html>
   );

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,3 +1,13 @@
+import Navbar from "@/components/Navbar";
+import Landing from "./(nondashboard)/landing/page";
+
 export default function Home() {
-  return  <div> home </div>;
+  return (
+    <div className="h-full w-full">
+      <Navbar />
+      <main className={`h-full flex w-full flex-col`}>
+        <Landing />
+      </main>
+    </div>
+  );
 }

--- a/frontend/src/components/ApplicationCard.tsx
+++ b/frontend/src/components/ApplicationCard.tsx
@@ -1,0 +1,127 @@
+import { Mail, MapPin, PhoneCall } from "lucide-react";
+import Image from "next/image";
+import React, { useState } from "react";
+
+const ApplicationCard = ({
+  application,
+  userType,
+  children,
+}: ApplicationCardProps) => {
+  const [imgSrc, setImgSrc] = useState(
+    application.property.photoUrls?.[0] || "/placeholder.jpg"
+  );
+
+  const statusColor =
+    application.status === "Approved"
+      ? "bg-green-500"
+      : application.status === "Denied"
+      ? "bg-red-500"
+      : "bg-yellow-500";
+
+  const contactPerson =
+    userType === "manager" ? application.tenant : application.manager;
+
+  return (
+    <div className="border rounded-xl overflow-hidden shadow-sm bg-white mb-4">
+      <div className="flex flex-col lg:flex-row  items-start lg:items-center justify-between px-6 md:px-4 py-6 gap-6 lg:gap-4">
+        {/* Property Info Section */}
+        <div className="flex flex-col lg:flex-row gap-5 w-full lg:w-auto">
+          <Image
+            src={imgSrc}
+            alt={application.property.name}
+            width={200}
+            height={150}
+            className="rounded-xl object-cover w-full lg:w-[200px] h-[150px]"
+            sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+            onError={() => setImgSrc("/placeholder.jpg")}
+          />
+          <div className="flex flex-col justify-between">
+            <div>
+              <h2 className="text-xl font-bold my-2">
+                {application.property.name}
+              </h2>
+              <div className="flex items-center mb-2">
+                <MapPin className="w-5 h-5 mr-1" />
+                <span>{`${application.property.location.city}, ${application.property.location.country}`}</span>
+              </div>
+            </div>
+            <div className="text-xl font-semibold">
+              ${application.property.pricePerMonth}{" "}
+              <span className="text-sm font-normal">/ month</span>
+            </div>
+          </div>
+        </div>
+
+        {/* Divider - visible only on desktop */}
+        <div className="hidden lg:block border-[0.5px] border-primary-200 h-48" />
+
+        {/* Status Section */}
+        <div className="flex flex-col justify-between w-full lg:basis-2/12 lg:h-48 py-2 gap-3 lg:gap-0">
+          <div>
+            <div className="flex justify-between items-center">
+              <span className="text-gray-500">Status:</span>
+              <span
+                className={`px-2 py-1 ${statusColor} text-white rounded-full text-sm`}
+              >
+                {application.status}
+              </span>
+            </div>
+            <hr className="mt-3" />
+          </div>
+          <div className="flex justify-between">
+            <span className="text-gray-500">Start Date:</span>{" "}
+            {new Date(application.lease?.startDate).toLocaleDateString()}
+          </div>
+          <div className="flex justify-between">
+            <span className="text-gray-500">End Date:</span>{" "}
+            {new Date(application.lease?.endDate).toLocaleDateString()}
+          </div>
+          <div className="flex justify-between">
+            <span className="text-gray-500">Next Payment:</span>{" "}
+            {new Date(application.lease?.nextPaymentDate).toLocaleDateString()}
+          </div>
+        </div>
+
+        {/* Divider - visible only on desktop */}
+        <div className="hidden lg:block border-[0.5px] border-primary-200 h-48" />
+
+        {/* Contact Person Section */}
+        <div className="flex flex-col justify-start gap-5 w-full lg:basis-3/12 lg:h-48 py-2">
+          <div>
+            <div className="text-lg font-semibold">
+              {userType === "manager" ? "Tenant" : "Manager"}
+            </div>
+            <hr className="mt-3" />
+          </div>
+          <div className="flex gap-4">
+            <div>
+              <Image
+                src="/landing-i1.png"
+                alt={contactPerson.name}
+                width={40}
+                height={40}
+                className="rounded-full mr-2 min-w-[40px] min-h-[40px]"
+              />
+            </div>
+            <div className="flex flex-col gap-2">
+              <div className="font-semibold">{contactPerson.name}</div>
+              <div className="text-sm flex items-center text-primary-600">
+                <PhoneCall className="w-5 h-5 mr-2" />
+                {contactPerson.phoneNumber}
+              </div>
+              <div className="text-sm flex items-center text-primary-600">
+                <Mail className="w-5 h-5 mr-2" />
+                {contactPerson.email}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <hr className="my-4" />
+      {children}
+    </div>
+  );
+};
+
+export default ApplicationCard;


### PR DESCRIPTION
wires up end-to-end “applications” flows for both managers and tenants, plus enhances the public landing page with a dynamic HeroSection and global toast notifications.

### Manager Applications Dashboard
**/dashboard/managers/applications/page.tsx**

    New tabbed view (“All / Pending / Approved / Denied”) powered by Radix Tabs

    Fetches manager’s applications via useGetApplicationsQuery (filtered by userType = "manager")

    Inline Approve / Deny buttons call useUpdateApplicationStatusMutation

Conditionally shows Download Agreement or Contact User actions

### Tenant Applications Dashboard
**/dashboard/tenants/applications/page.tsx**

    Lists tenant’s own applications via useGetApplicationsQuery ({ userType: "tenant" })

    Status banners for Approved / Pending / Denied with matching icons

    Download Agreement button for all statuses

### ApplicationCard Component
New reusable card under /components/ApplicationCard.tsx

    Displays property image, name, location, rent, status badge, lease dates, next payment, and contact info

    Accepts children to render context-specific actions

###  Landing Page Enhancements
**HeroSection.tsx**

    Client-side component that lets users “Search location” via Mapbox Geocoding API

    On search, dispatches setFilters({ location, coordinates }) and routes to /search?…

    Added useState, useDispatch, and useRouter for full React/Redux/Next integration

**RootLayout.tsx**

    Imported and rendered <Toaster /> globally so toast notifications can be triggered anywhere

**app/page.tsx**

    Swapped dummy Home for real composition: <Navbar /> + <Landing /> (which includes HeroSection)

